### PR TITLE
avoid possible type mismatch in `specular_exponent` and `reflection`

### DIFF
--- a/src/gradients/zygote.jl
+++ b/src/gradients/zygote.jl
@@ -158,7 +158,7 @@ end
     
 @adjoint literal_getproperty(m::Material, ::Val{:specular_exponent}) =
     getproperty(m, :specular_exponent), Δ -> (Material(zero(m.color_ambient), zero(m.color_diffuse),
-                                                       zero(m.color_specular), Δ, zero(m.reflection),
+                                                       zero(m.color_specular), Δ, zero(Δ),
                                                        isnothing(m.texture_ambient) ? nothing : zero(m.texture_ambient),
                                                        isnothing(m.texture_diffuse) ? nothing : zero(m.texture_diffuse),
                                                        isnothing(m.texture_specular) ? nothing : zero(m.texture_specular),


### PR DESCRIPTION
In trying to run the `inverse_lighting.jl` example, I got the following error:
```
ERROR: MethodError: no method matching Material(::Vec3{Array{Float32,1}}, ::Vec3{Array{Float32,1}}, ::Vec3{Array{Float32,1}}, ::Array{Complex{Float32},1}, ::Array{Float32,1}, ::Nothing, ::Nothing, ::Nothing, ::Nothing)
Closest candidates are:
  Material(::Vec3{T}, ::Vec3{T}, ::Vec3{T}, ::R, ::R, ::U, ::V, ::W, ::S) where {T<:AbstractArray, R<:(AbstractArray{T,1} where T), U<:Union{Nothing, Vec3}, V<:Union{Nothing, Vec3}, W<:Union{Nothing, Vec3}, S<:Union{Nothing, Array{T,1} where T}} at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/dev/RayTracer/src/materials.jl:44
Stacktrace:
 [1] (::RayTracer.var"#238#239"{Material{Array{Float32,1},Array{Float32,1},Nothing,Nothing,Nothing,Nothing}})(::Array{Complex{Float32},1}) at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/dev/RayTracer/src/gradients/zygote.jl:160
 [2] (::RayTracer.var"#4938#back#240"{RayTracer.var"#238#239"{Material{Array{Float32,1},Array{Float32,1},Nothing,Nothing,Nothing,Nothing}}})(::Array{Complex{Float32},1}) at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/packages/ZygoteRules/6nssF/src/adjoint.jl:49
 [3] specular_exponent at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/dev/RayTracer/src/materials.jl:213 [inlined]
 [4] (::typeof(∂(specular_exponent)))(::Complex{Float32}) at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/packages/Zygote/iOhwI/src/compiler/interface2.jl:0
 [5] specular_exponent at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/dev/RayTracer/src/objects.jl:29 [inlined]
 [6] (::typeof(∂(specular_exponent)))(::Complex{Float32}) at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/packages/Zygote/iOhwI/src/compiler/interface2.jl:0
 [7] light at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/dev/RayTracer/src/renderers/blinnphong.jl:46 [inlined]
 [8] (::typeof(∂(light)))(::Vec3{Array{Float32,1}}) at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/packages/Zygote/iOhwI/src/compiler/interface2.jl:0
 [9] raytrace at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/dev/RayTracer/src/renderers/blinnphong.jl:104 [inlined]
 [10] (::typeof(∂(raytrace)))(::Vec3{Array{Float32,1}}) at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/packages/Zygote/iOhwI/src/compiler/interface2.jl:0
 [11] render at /home/jeff/talks/odsc2020/inverse_lighting.jl:44 [inlined]
 [12] (::typeof(∂(render)))(::Array{Float32,4}) at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/packages/Zygote/iOhwI/src/compiler/interface2.jl:0
 [13] #13 at ./none:2 [inlined]
 [14] (::typeof(∂(#13)))(::Float32) at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/packages/Zygote/iOhwI/src/compiler/interface2.jl:0
 [15] (::Zygote.var"#36#37"{typeof(∂(#13))})(::Float32) at /home/jeff/.juliapro/JuliaPro_v1.4.0-1/packages/Zygote/iOhwI/src/compiler/interface.jl:38
 [16] top-level scope at none:0
```
`Δ` was a complex array and `m.reflection` was not. I have no idea whether this is correct, but it seemed to fix the problem.